### PR TITLE
tidyverse-style reshape

### DIFF
--- a/Chapter2_MeasurementData.R
+++ b/Chapter2_MeasurementData.R
@@ -346,6 +346,16 @@ head(HCI.long, n = 3)
 # HCI.long$item <- as.factor(HCI.long$item)
 #--------------
 
+# tidyverse approach
+library(tidyverse)
+
+HCI.long <- pivot_longer(
+  data = HCI,
+  cols = starts_with("Item"),
+  names_to = "item", values_to = "rating"
+)
+
+
 #--------------
 HCI.wide <- reshape(
   data = HCI.long,
@@ -361,6 +371,10 @@ head(HCI.wide, n = 3)
 ## 3      1     1    17      3 1.3155        1        1 
 ## ...
 #--------------
+
+# tidyverse approach
+HCI.wide <- pivot_wider(data = HCI.long, names_from = item, values_from = rating)
+
 
 #-----------------------------------------------------------------
 # 2.6 Random variables


### PR DESCRIPTION
Note that `HCI` pivoted from long to wide has names \`1\`, \`2\` and so on, because `HCI.long` Item variable was constructed to only contain integers (`HCI.long` from `pivot_longer` retains the original column names).

Code style note: Generally, using dots in object names is discouraged, because in most object-oriented languages a dot has syntactical meaning; even in `R` a dot indicates S3 method (in format `generic.class`).